### PR TITLE
Swap to using open_text from importlib_resources

### DIFF
--- a/src/etc/etc.py
+++ b/src/etc/etc.py
@@ -34,7 +34,7 @@ class ETC(object):
     _V_band = SpectralElement.from_filter("johnson_v")
 
     def __init__(self, config_file=None, components=None):
-        PRESET_MODELS = toml.loads(pkg_resources.read_text(data, "FTN_FLOYDS.toml"))
+        PRESET_MODELS = toml.load(pkg_resources.open_text(data, "FTN_FLOYDS.toml"))
         self.components = components if components is not None else []
         if config_file is None and len(self.components) == 0:
             component_config = PRESET_MODELS


### PR DESCRIPTION
## Change Description
`read_text()` from `importlib_resources` is now deprecated and the github actions is complaining
- [ ] My PR includes a link to the issue that I am addressing



## Solution Description
Swapped from doing a `toml.loads` of the string returned by `pkg_resources.read_text()` to a `toml.load` on the file pointer returned by `pkg_resources.open_text()` from the newer `files()` interface



## Code Quality
- [X] I have read the Contribution Guide
- [X] My code follows the code style of this project
- [X] My code builds (or compiles) cleanly without any errors or warnings
- [X] My code contains relevant comments and necessary documentation
